### PR TITLE
Dc/early scaffolding

### DIFF
--- a/components/header.jsx
+++ b/components/header.jsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import RRLogoSvg from "../components/rr-logo-svg.jsx";
+import { css, jsx } from "@emotion/core";
+
+// this comment tells babel to convert jsx to calls to a function called jsx instead of React.createElement
+/** @jsx jsx */
+
+const headerStyle = css`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const homeLogoLinkStyle = css`
+  cursor: pointer;
+  width: 60px;
+  flex: 0 0 auto;
+`;
+
+const textLinkStyle = css`
+  flex: 0 0 auto;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 250ms;
+  margin-right: 2vw;
+  color: #505050;
+  &:hover {
+    color: #000000;
+  }
+`;
+
+const Header = () => (
+  <header css={headerStyle}>
+    <Link href="/">
+      <a css={homeLogoLinkStyle}>
+        <RRLogoSvg />
+      </a>
+    </Link>
+    <Link href="/about">
+      <a css={textLinkStyle} title="About Page">
+        About
+      </a>
+    </Link>
+  </header>
+);
+
+export default Header;

--- a/components/main-layout.jsx
+++ b/components/main-layout.jsx
@@ -1,0 +1,35 @@
+import Header from "./header.jsx";
+import Head from "next/head";
+import { css, Global, jsx } from "@emotion/core";
+
+// this comment tells babel to convert jsx to calls to a function called jsx instead of React.createElement
+/** @jsx jsx */
+
+const globalStyle = css`
+  * {
+    box-sizing: border-box;
+    font-family: "Slabo 27px", serif;
+  }
+`;
+
+const MainLayout = props => {
+  const { children } = props;
+  return (
+    <>
+      <Head>
+        <title>Repro</title>
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+        <link
+          href="https://fonts.googleapis.com/css?family=Slabo+27px&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+
+      <Global styles={globalStyle} />
+      <Header />
+      {children}
+    </>
+  );
+};
+
+export default MainLayout;

--- a/pages/about.jsx
+++ b/pages/about.jsx
@@ -1,7 +1,20 @@
+import MainLayout from "../components/main-layout.jsx";
+import { css, jsx } from "@emotion/core";
+
+// this comment tells babel to convert jsx to calls to a function called jsx instead of React.createElement
+/** @jsx jsx */
+
+const aboutTextStyle = css`
+  width: 80%;
+  margin: 0 auto;
+`;
+
 const About = () => (
-  <p>
-    Repro is a tool for working together to reproduce and squash bugs.
-  </p>
+  <MainLayout>
+    <p css={aboutTextStyle}>
+      Repro is a tool for working together to reproduce and squash bugs.
+    </p>
+  </MainLayout>
 );
 
 export default About;

--- a/pages/bug/[bugHashedId].js
+++ b/pages/bug/[bugHashedId].js
@@ -1,0 +1,45 @@
+import Head from 'next/head';
+import MainLayout from "../../components/main-layout.jsx";
+
+const BugPage = (props) => {
+  const {
+    actualBehavior,
+    bugHashedId,
+    expectedBehavior,
+    stepsToRepro,
+    title,
+  } = props;
+
+  return (
+    <MainLayout>
+      <h1>{title}</h1>
+      <h3>Expected Behavior</h3>
+      <p>{expectedBehavior}</p>
+      <h3>Actual Behavior</h3>
+      <p>{actualBehavior}</p>
+      <h3>Steps To Repro</h3>
+      <ul>
+        {stepsToRepro.map(step => (
+          <li key={step}>{step}</li>
+        ))}
+      </ul>
+    </MainLayout>
+  );
+};
+
+BugPage.getInitialProps = async ({ query }) => {
+  const { bugHashedId } = query;
+  // todo: hit our API with this bug hashed id to get the bug in question,
+  // so we can use real data in the UI
+  return {
+    bugHashedId,
+    title: 'What a bug title',
+    expectedBehavior: 'A thing happens',
+    actualBehavior: 'A thing does not happen',
+    stepsToRepro: [
+      'Turn on your computer', 'Open a web browser', 'Try to do a thing',
+    ],
+  };
+}
+
+export default BugPage;

--- a/pages/bugs/[id].js
+++ b/pages/bugs/[id].js
@@ -3,11 +3,20 @@ import MainLayout from "../../components/main-layout.jsx";
 const BugPage = (props) => {
   const {
     actualBehavior,
+    error,
     id,
     expectedBehavior,
     stepsToRepro,
     title,
   } = props;
+
+  if (error) {
+    return (
+      <MainLayout>
+        <p>{error}: {id}</p>
+      </MainLayout>
+    )
+  }
 
   return (
     <MainLayout>
@@ -32,6 +41,20 @@ BugPage.getInitialProps = async ({ query }) => {
   const { id } = query;
   // todo: hit our API with this bug hashed id to get the bug in question,
   // so we can use real data in the UI
+
+  const validIds = [
+    'abc123',
+    'def456',
+    'ghi789',
+  ];
+
+  if (!(validIds.includes(id))) {
+    return {
+      error: 'Bug not found',
+      id
+    };
+  }
+
   return {
     id,
     title: 'What a bug title',

--- a/pages/bugs/[id].js
+++ b/pages/bugs/[id].js
@@ -1,10 +1,9 @@
-import Head from 'next/head';
 import MainLayout from "../../components/main-layout.jsx";
 
 const BugPage = (props) => {
   const {
     actualBehavior,
-    bugHashedId,
+    id,
     expectedBehavior,
     stepsToRepro,
     title,
@@ -13,6 +12,8 @@ const BugPage = (props) => {
   return (
     <MainLayout>
       <h1>{title}</h1>
+      <h3>Bug id</h3>
+      <p>{id}</p>
       <h3>Expected Behavior</h3>
       <p>{expectedBehavior}</p>
       <h3>Actual Behavior</h3>
@@ -28,11 +29,11 @@ const BugPage = (props) => {
 };
 
 BugPage.getInitialProps = async ({ query }) => {
-  const { bugHashedId } = query;
+  const { id } = query;
   // todo: hit our API with this bug hashed id to get the bug in question,
   // so we can use real data in the UI
   return {
-    bugHashedId,
+    id,
     title: 'What a bug title',
     expectedBehavior: 'A thing happens',
     actualBehavior: 'A thing does not happen',

--- a/pages/bugs/index.jsx
+++ b/pages/bugs/index.jsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import MainLayout from "../../components/main-layout.jsx";
+
+const BugLink = (props) => {
+  const { id } = props;
+  return (
+    <li>
+      <Link href="/bugs/[id]" as={`/bugs/${id}`}>
+        <a>{id}</a>
+      </Link>
+    </li>
+  );
+}
+
+
+const BugsIndex = () => {
+  return (
+    <MainLayout>
+      <ul>
+        <BugLink id="abc123"/>
+        <BugLink id="def456"/>
+        <BugLink id="ghi789"/>
+      </ul>
+    </MainLayout>
+  );
+};
+
+export default BugsIndex;

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,17 +1,10 @@
-import Link from 'next/link';
-import Head from 'next/head';
-import RRLogoSvg from '../components/rr-logo-svg.jsx';
+import Link from "next/link";
+import RRLogoSvg from "../components/rr-logo-svg.jsx";
+import MainLayout from "../components/main-layout.jsx";
+import { css, Global, jsx } from "@emotion/core";
+
 // this comment tells babel to convert jsx to calls to a function called jsx instead of React.createElement
 /** @jsx jsx */
-import { css, Global, jsx } from '@emotion/core'
-
-
-const globalStyle = css`
-  * {
-    box-sizing: border-box;
-    font-family: 'Slabo 27px', serif;
-  }
-`;
 
 const logoContainerStyle = css`
   max-width: 200px;
@@ -27,34 +20,17 @@ const verticallyCenteredContentStyle = css`
   top: 50%;
   left: 50%;
   transform: translateX(-50%) translateY(-50%);
-
 `;
 
 const Index = () => (
-  <>
-    <Head>
-      <title>Repro</title>
-      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-      <link href="https://fonts.googleapis.com/css?family=Slabo+27px&display=swap" rel="stylesheet" />
-    </Head>
-
-    <Global
-      styles={globalStyle}
-    />
-
-    <div
-      css={verticallyCenteredContentStyle}
-    >
-      <div
-        css={logoContainerStyle}
-        >
-          <RRLogoSvg
-            style={logoContainerStyle}
-          />
-        </div>
-        <h2 css={comingSoonStyle}>coming soon to a bug near you</h2>
+  <MainLayout>
+    <div css={verticallyCenteredContentStyle}>
+      <div css={logoContainerStyle}>
+        <RRLogoSvg />
+      </div>
+      <h2 css={comingSoonStyle}>coming soon to a bug near you</h2>
     </div>
-  </>
+  </MainLayout>
 );
 
 export default Index;


### PR DESCRIPTION
This PR adds a bit more scaffolding-type stuff to the app, including:

- a main layout component
- a header component (included in the main layout component)
- a bugs index page: `/bugs`
- a bug show page: `/bugs/abc123`
- [dynamic routing](https://nextjs.org/docs#dynamic-routing), to show any bug via that one bug show page: `bugs/[id]`
- some error handling, to show an error if the bug id isn't in our hard-coded list of fake ids